### PR TITLE
Fall back to `copyTo` option as a `remoteCopy` dest

### DIFF
--- a/lib/shipit.js
+++ b/lib/shipit.js
@@ -244,7 +244,7 @@ Shipit.prototype.remoteCopy = function (src, dest, options, callback) {
     ignores: this.config && this.config.ignores ? this.config.ignores : []
   });
 
-  return this.pool.copy(src, dest, options, callback);
+  return this.pool.copy(src, dest || this.config.copyTo, options, callback);
 };
 
 /**


### PR DESCRIPTION
In symmetry with `deployTo` I added a `copyTo` as a fallback for `remoteCopy`'s `dest` parameter.
TBH I'm not too crazy about `deployTo` nor `copyTo` but wanted to keep it symmetrical.

IMO it doesn't make sense to hardwire task types in task configuration option names, it would be far more flexible if they were more generic, e.g. `dest`. The remote destination directory is (to me) part of server configuration, not task configuration, which is why I propose this change to begin with.

And since I'm criticising anyway (sorry 'bout that, I honestly mean it to be constructive) the generic name of the "deploy" task bothers me too, since rsyncing something to a remote host is deployment as well, i.e. it would be far more clear to skip a default "deploy" task and rename it to "sync", then in the server configuration I'd go for a `type` option which has value 'git' or 'rsync'. It would make it a lot more flexible and expandable (if you'd choose to add some transfer types later on) Or instead of strings, let it accept node modules. E.g.:

```js
var git = require("shipit-git"); //renamed module
var rsync = require("shipit-rsync");
shipit.initConfig({
	staging: {
		repositoryUrl: 'https://github.com/example/example',
		ignores: ['.git', 'node_modules'],
		servers: 'user@staging.example.com', 
		dest: '/home/user/app',
		workspace : '/tmp/shipit'
		type : git
	},
	production : {
		ignores: ['.git'],
		servers: 'user@production.example.com', 
		dest: '/home/user/awesome',
		type: rsync
	}
});
```

Allowing this to run with `shipit staging sync` and `shipit production sync`.

And when we're on the subject of configuration ... (I'm really sorry, you can just ignore my ramblings) A powerful concept of shipit IMO is the possibility to extract it from the usual build automation stuff I put in my repos because of the baked in git stuff. Which means I could bundle all of the deployment tasks of a project into a single repo. E.g. I've got a REST server app and a web client which connects to the REST API. In that case, most probably both are hosted on the same server, yet in different directories for instance. Therefore it would be pretty handy to have an intermediate configuration level. I.e. there's already server and task configuration, but it would be beneficial to add some kind of "target" configuration.

Something like this:

```js
var git = require("shipit-git"); //renamed module
var rsync = require("shipit-rsync");
shipit.initServers({
  staging: {
      servers: 'user@staging.example.com'
  },
  production : {
	  servers: 'user@production.example.com',
  }
});

shipit.initTargets({
	client : {
		ignores: ['.git', 'node_modules'],
		repositoryUrl: 'https://github.com/example/example',
		dest: '/home/user/client',
 		workspace : '/tmp/shipit'
		type : git
	},
	rest : {
		ignores: ['.git'],
		dest: '/home/user/rest',
		type: rsync	
	}
});
```

And usage would be something like:

```sh
$ shipit staging:client sync
# and
$ shipit production:rest sync
```

Again, sorry for this lengthy rant and I realise the above is A LOOOOT of work. I'm just giving feedback on an awesome tool and hope to see it become even more awesome. If you _are_ interested though, **I can certainly help out with the lion share.**